### PR TITLE
Update freegeoip url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const GEO_API_URL = 'https://freegeoip.net/json/';
+const GEO_API_URL = 'https://freegeoip.app/json/';
 const COUNTRY_META_API = 'https://restcountries.eu/rest/v2/alpha/';
 const EXCHANGE_RATES_API = 'https://openexchangerates.org/api/latest.json';
 const QUANDL_API = 'https://www.quandl.com/api/v3/';


### PR DESCRIPTION
freegeoip.net has been shut down (as of July 2018), but someone has created freegeoip.app, which apparently does exactly the same thing, just on a different TLD. I found it through [this issue](https://github.com/wet-boew/wet-boew/issues/8365).